### PR TITLE
World boss scaling

### DIFF
--- a/modules/mod-player-settings/src/PlayerSettings.cpp
+++ b/modules/mod-player-settings/src/PlayerSettings.cpp
@@ -138,7 +138,7 @@ public:
         if (!mapInfo->veto)
             mapInfo->veto = mapInfo->nplayers;
 
-        if (mapInfo->nplayers > 1 && oldArea != newArea)
+        if (mapInfo->nplayers > 5 && oldArea != newArea)
         {
             if (std::find(WorldBossZoneArray.begin(), WorldBossZoneArray.end(), newArea) != WorldBossZoneArray.end())
                 for (Map::PlayerList::const_iterator iter = players.begin(); iter != players.end(); ++iter)

--- a/modules/mod-player-settings/src/PlayerSettings.cpp
+++ b/modules/mod-player-settings/src/PlayerSettings.cpp
@@ -16,12 +16,36 @@
 #include <cstdlib>
 #include <vector>
 
-#define BOSS_VAELASTRASZ    13020
-
 // DPS count as 1 offensive unit. Tanks and healers count as 1 defensive unit.
-
 // 5 man: 1 tank, 3 dps, 1 healer = 3 offensive units and 2 defensive units.
 const float Offence5M = 1 / 3.0f, Defence5M = 1 / 2.0f;
+
+enum WorldBosses
+{
+    BOSS_VAELASTRASZ    = 13020,
+    BOSS_TAERAR         = 14890,
+    BOSS_EMERISS        = 14889,
+    BOSS_LETHON         = 14888,
+    BOSS_YSONDRE        = 14887
+};
+
+std::array<uint32, 5> WorldBossArray =
+{
+    BOSS_VAELASTRASZ, BOSS_TAERAR, BOSS_EMERISS, BOSS_LETHON, BOSS_YSONDRE
+};
+
+enum WorldBossZones
+{
+    ZONE_TAERAR     = 10,
+    ZONE_EMERISS    = 47,
+    ZONE_LETHON     = 357,
+    ZONE_YSONDRE    = 331
+};
+
+std::array<uint32, 4> WorldBossZoneArray =
+{
+    ZONE_TAERAR, ZONE_EMERISS, ZONE_LETHON, ZONE_YSONDRE
+};
 
 enum Spells
 {
@@ -54,6 +78,8 @@ public:
     PlayerSettingsMapInfo() {}
     uint32 nplayers = 0;
     uint32 veto = 0;
+    uint32 zone = 0;
+    uint32 area = 0;
     std::map<uint32, float> honor;
     std::map<uint32, bool> rewarded;
     std::map<uint32, uint32> rdf;
@@ -350,6 +376,17 @@ private:
         return target->GetMap()->IsBattleground() && attacker->GetMap()->IsBattleground();
     }
 
+    bool isWorldBoss(Unit *target, Unit *attacker)
+    {
+        if (std::find(WorldBossArray.begin(), WorldBossArray.end(), target->GetEntry()) != WorldBossArray.end())
+            return true;
+
+        if (std::find(WorldBossArray.begin(), WorldBossArray.end(), attacker->GetEntry()) != WorldBossArray.end())
+            return true;
+
+        return false;
+    }
+
     bool check(Unit* attacker, Unit* target)
     {
         if (!target || !target->GetMap())
@@ -357,6 +394,9 @@ private:
 
         if (!attacker || !attacker->GetMap())
             return false;
+
+        if (isWorldBoss(target, attacker))
+            return true;
 
         if (!inDungeon(target, attacker) || inBattleground(target, attacker))
             return false;
@@ -369,7 +409,10 @@ private:
         PlayerSettingsMapInfo *mapInfo = target->GetMap()->CustomData.GetDefault<PlayerSettingsMapInfo>("PlayerSettingsMapInfo");
         InstanceMap *instanceMap = ((InstanceMap *)sMapMgr->FindMap(target->GetMapId(), target->GetInstanceId()));
 
-        if (!instanceMap)
+        // is this needed? check is done before modify is called
+        // if (!instanceMap)
+        //     return amount;
+        if (!check(attacker, target))
             return amount;
 
         uint32 nplayers = std::max(mapInfo->nplayers, mapInfo->veto);
@@ -449,7 +492,10 @@ public:
             return;
 
         PlayerSettingsMapInfo *mapInfo = map->CustomData.GetDefault<PlayerSettingsMapInfo>("PlayerSettingsMapInfo");
+        Map::PlayerList const &players = map->GetPlayers();
         mapInfo->nplayers = map->GetPlayersCountExceptGMs();
+        mapInfo->zone = player->GetZoneId();
+        mapInfo->area = player->GetAreaId();
 
         if (!mapInfo->nplayers)
             mapInfo->nplayers = 1;
@@ -457,15 +503,18 @@ public:
         if (!mapInfo->veto)
             mapInfo->veto = mapInfo->nplayers;
 
-        if (map->GetEntry()->IsDungeon() && player)
-        {
-            Map::PlayerList const &players = map->GetPlayers();
-
-            if (mapInfo->nplayers > 1)
-                for (Map::PlayerList::const_iterator iter = players.begin(); iter != players.end(); ++iter)
-                    if (Player *handle = iter->GetSource())
+        for (Map::PlayerList::const_iterator iter = players.begin(); iter != players.end(); ++iter)
+            if (Player *handle = iter->GetSource())
+            {
+                if (mapInfo->nplayers > 0)
+                {
+                    if (map->GetEntry()->IsDungeon())
                         ChatHandler(handle->GetSession()).PSendSysMessage("%s has entered the instance. The minions of hell grow stronger.", player->GetName().c_str());
-        }
+
+                    if (std::find(WorldBossZoneArray.begin(), WorldBossZoneArray.end(), mapInfo->area) != WorldBossZoneArray.end())
+                        ChatHandler(handle->GetSession()).PSendSysMessage("%s has entered a World Boss area. The minions of hell grow stronger.", player->GetName().c_str());
+                }
+            }
     }
 
     void OnPlayerLeaveAll(Map *map, Player *player)
@@ -477,30 +526,23 @@ public:
             return;
 
         PlayerSettingsMapInfo *mapInfo = map->CustomData.GetDefault<PlayerSettingsMapInfo>("PlayerSettingsMapInfo");
+        Map::PlayerList const &players = map->GetPlayers();
 
-        if (map->GetEntry() && map->GetEntry()->IsDungeon())
-        {
-            bool check = false;
-            Map::PlayerList const &players = map->GetPlayers();
-
-            for (Map::PlayerList::const_iterator iter = players.begin(); iter != players.end(); ++iter)
-                if (Player *player = iter->GetSource())
-                    if (player->IsInCombat())
-                        check = true;
-
-            if (!check)
-                mapInfo->nplayers = map->GetPlayersCountExceptGMs() - 1;
-        }
-
-        if (map->GetEntry()->IsDungeon())
-        {
-            Map::PlayerList const &players = map->GetPlayers();
-
-            if (mapInfo->nplayers > 0)
-                for (Map::PlayerList::const_iterator iter = players.begin(); iter != players.end(); ++iter)
-                    if (Player *handle = iter->GetSource())
+        for (Map::PlayerList::const_iterator iter = players.begin(); iter != players.end(); ++iter)
+            if (Player *handle = iter->GetSource())
+            {
+                if (!player->IsInCombat())
+                    mapInfo->nplayers = map->GetPlayersCountExceptGMs() - 1;
+        
+                if (mapInfo->nplayers > 0)
+                {
+                    if (map->GetEntry()->IsDungeon())
                         ChatHandler(handle->GetSession()).PSendSysMessage("%s has left the instance. The minions of hell grow weaker.", player->GetName().c_str());
-        }
+                
+                    if (std::find(WorldBossZoneArray.begin(), WorldBossZoneArray.end(), player->GetAreaId()) != WorldBossZoneArray.end())
+                        ChatHandler(handle->GetSession()).PSendSysMessage("%s has left a World Boss area. The minions of hell grow weaker.", player->GetName().c_str());
+                }
+            }
     }
 };
 
@@ -521,9 +563,13 @@ public:
     {
         if (!creature || !creature->GetMap())
             return;
+        
+        if (!creature->IsAlive())
+            return;
 
         if (!creature->GetMap()->IsDungeon())
-            return;
+            if (!(std::find(WorldBossArray.begin(), WorldBossArray.end(), creature->GetEntry()) != WorldBossArray.end()))
+                return;
 
         if (((creature->IsHunterPet() || creature->IsPet() || creature->IsSummon()) && creature->IsControlledByPlayer()))
             return;
@@ -533,15 +579,11 @@ public:
         InstanceMap *instanceMap = ((InstanceMap *)sMapMgr->FindMap(creature->GetMapId(), creature->GetInstanceId()));
         PlayerSettingsCreatureInfo *creatureInfo = creature->CustomData.GetDefault<PlayerSettingsCreatureInfo>("PlayerSettingsCreatureInfo");
 
-        if (!creature->IsAlive())
-            return;
-
+        creatureInfo->entry = creature->GetEntry();
         creatureInfo->nplayers = std::max(mapInfo->nplayers, mapInfo->veto);
 
         if (!creatureInfo->nplayers)
             return;
-
-        creatureInfo->entry = creature->GetEntry();
 
         CreatureBaseStats const *stats = sObjectMgr->GetCreatureBaseStats(creature->getLevel(), creatureTemplate->unit_class);
         uint32 baseHealth = stats->GenerateHealth(creatureTemplate);
@@ -571,21 +613,20 @@ public:
         uint32 scaledCurrentHealth = previousHealth && previousMaxHealth ? float(scaledHealth) / float(previousMaxHealth) * float(previousHealth) : 0;
 
         static bool initialized;
-        if (creatureInfo->entry = creature->GetEntry() == BOSS_VAELASTRASZ)
+        if (std::find(WorldBossArray.begin(), WorldBossArray.end(), creature->GetEntry()) != WorldBossArray.end())
         {
             creature->SetHealth(scaledCurrentHealth);
             creature->UpdateAllStats();
             return;
         }
-        else
+
+        if (!initialized)
         {
-            if (!initialized)
-            {
-                initialized = true;
-                creature->SetHealth(scaledCurrentHealth);
-                creature->UpdateAllStats();
-            }
+            initialized = true;
+            creature->SetHealth(scaledCurrentHealth);
+            creature->UpdateAllStats();
         }
+
     }
 };
 

--- a/modules/mod-player-settings/src/PlayerSettings.cpp
+++ b/modules/mod-player-settings/src/PlayerSettings.cpp
@@ -26,12 +26,16 @@ enum WorldBosses
     BOSS_TAERAR         = 14890,
     BOSS_EMERISS        = 14889,
     BOSS_LETHON         = 14888,
-    BOSS_YSONDRE        = 14887
+    BOSS_YSONDRE        = 14887,
+    BOSS_AZUREGOS       = 6109,
+    BOSS_KAZZAK         = 12397,
+    BOSS_TEREMUS        = 7846
 };
 
-std::array<uint32, 5> WorldBossArray =
+std::array<uint32, 8> WorldBossArray =
 {
-    BOSS_VAELASTRASZ, BOSS_TAERAR, BOSS_EMERISS, BOSS_LETHON, BOSS_YSONDRE
+    BOSS_VAELASTRASZ, BOSS_TAERAR, BOSS_EMERISS, BOSS_LETHON,
+    BOSS_YSONDRE, BOSS_AZUREGOS, BOSS_KAZZAK, BOSS_TEREMUS
 };
 
 enum WorldBossZones
@@ -39,12 +43,16 @@ enum WorldBossZones
     ZONE_TAERAR     = 10,
     ZONE_EMERISS    = 47,
     ZONE_LETHON     = 357,
-    ZONE_YSONDRE    = 331
+    ZONE_YSONDRE    = 331,
+    ZONE_AZUREGOS   = 61,
+    ZONE_KAZZAK     = 4,
+    ZONE_TEREMUS    = 4
 };
 
-std::array<uint32, 4> WorldBossZoneArray =
+std::array<uint32, 7> WorldBossZoneArray =
 {
-    ZONE_TAERAR, ZONE_EMERISS, ZONE_LETHON, ZONE_YSONDRE
+    ZONE_TAERAR, ZONE_EMERISS, ZONE_LETHON, ZONE_YSONDRE,
+    ZONE_AZUREGOS, ZONE_KAZZAK, ZONE_TEREMUS
 };
 
 enum Spells

--- a/modules/mod-player-settings/src/PlayerSettings.cpp
+++ b/modules/mod-player-settings/src/PlayerSettings.cpp
@@ -28,13 +28,16 @@ enum WorldBosses
     BOSS_LETHON         = 14888,
     BOSS_YSONDRE        = 14887,
     BOSS_AZUREGOS       = 6109,
-    BOSS_KAZZAK         = 12397
+    BOSS_KAZZAK         = 12397,
+    BOSS_MAWS           = 15571,
+    BOSS_ERANIKUS       = 15491,
 };
 
-std::array<uint32, 8> WorldBossArray =
+std::array<uint32, 9> WorldBossArray =
 {
     BOSS_VAELASTRASZ, BOSS_TAERAR, BOSS_EMERISS, BOSS_LETHON,
-    BOSS_YSONDRE, BOSS_AZUREGOS, BOSS_KAZZAK
+    BOSS_YSONDRE, BOSS_AZUREGOS, BOSS_KAZZAK, BOSS_MAWS,
+    BOSS_ERANIKUS
 };
 
 enum WorldBossZones
@@ -47,7 +50,7 @@ enum WorldBossZones
     ZONE_KAZZAK     = 73  // The Tainted Scar
 };
 
-std::array<uint32, 7> WorldBossZoneArray =
+std::array<uint32, 6> WorldBossZoneArray =
 {
     ZONE_TAERAR, ZONE_EMERISS, ZONE_LETHON, ZONE_YSONDRE,
     ZONE_AZUREGOS, ZONE_KAZZAK


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  updated player settings module to include world boss scaling
-  added scaling for Taerar
- added scaling for Emeriss
- added scaling for Lethon
- added scaling for ysondre
- added scaling for azuregos
- added scaling for kazzak
- added scaling for maws
- added scaling for eranikus
- added announcement when players enter a world boss area


## Tests Performed:
- no build errors
- teleport to duskwood
- enter the twilight grove
- check system message received
- click Taerar and check health. should scale down to be between 200-300k
- start battle and check damage.
- teleport to Azshara
- goto 65.6, 54.6
- additem 21136
- use Arcanite Buoy to summon maws
- click maws and check health, should scale to around 350k
- start a battle with maws and check the damage.
